### PR TITLE
http.go: Make negotiateHeader match case insensitive

### DIFF
--- a/khttp/http.go
+++ b/khttp/http.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	negotiateHeader       = "Negotiate"
+	negotiateHeader       = "negotiate"
 	wwwAuthenticateHeader = "WWW-Authenticate"
 	authorizationHeader   = "Authorization"
 )
@@ -83,7 +83,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	authReply := strings.Split(resp.Header.Get(wwwAuthenticateHeader), " ")
-	if len(authReply) != 2 || authReply[0] != negotiateHeader {
+	if len(authReply) != 2 || strings.ToLower(authReply[0]) != negotiateHeader {
 		return nil, errors.New("khttp: server replied with invalid www-authenticate header")
 	}
 


### PR DESCRIPTION
Certain services return "negotiate" instead of "Negotiate", causing the
Transport.RoundTrip() method to return an error. This is solved by ignoring
the case while matching.