### PR TITLE
authenticate_gss_server_step: fix memory leaks

### DIFF
--- a/kerberosgss.c
+++ b/kerberosgss.c
@@ -362,17 +362,17 @@ int authenticate_gss_server_step(
         &state->client_creds
     );
     
-    if (GSS_ERROR(state->maj_stat)) {
-        ret = AUTH_GSS_ERROR;
-        goto end;
-    }
-    
     // Grab the server response to send back to the client
     if (output_token.length) {
         state->response = base64_encode(
             (const unsigned char *)output_token.value, output_token.length
         );;
-        state->maj_stat = gss_release_buffer(&state->min_stat, &output_token);
+        gss_release_buffer(&state->min_stat, &output_token);
+    }
+    
+    if (GSS_ERROR(state->maj_stat)) {
+        ret = AUTH_GSS_ERROR;
+        goto end;
     }
     
     // Get the user name


### PR DESCRIPTION
In `authenticate_gss_server_step` there are two memory leaks:

- `target_name` gets malloc'd by `gss_inquire_context`, but never gets free'd by `gss_release_name`. See `targ_name` [here](https://docs.oracle.com/cd/E36784_01/html/E36875/gss-inquire-context-3gss.html).
- `output_token` gets malloc'd in `gss_display_name` on line 379, but isn't free'd by `gss_release_buffer` before reuse on line 403. See `output_name_buffer` [here](https://docs.oracle.com/cd/E36784_01/html/E36875/gss-display-name-3gss.html).

I ran some tests internally using `valgrind` to verify. Here was the output:

Before:
```
==1014051== LEAK SUMMARY:
==1014051==    definitely lost: 61,000 bytes in 2,000 blocks
==1014051==    indirectly lost: 288,932 bytes in 9,997 blocks
==1014051==      possibly lost: 5,168 bytes in 17 blocks
==1014051==    still reachable: 3,929 bytes in 32 blocks
==1014051==         suppressed: 0 bytes in 0 blocks
```
After:
```
==1105036== LEAK SUMMARY:
==1105036==    definitely lost: 0 bytes in 0 blocks
==1105036==    indirectly lost: 0 bytes in 0 blocks
==1105036==      possibly lost: 4,256 bytes in 14 blocks
==1105036==    still reachable: 3,861 bytes in 29 blocks
==1105036==         suppressed: 0 bytes in 0 blocks
```

I also made a minor update to propagate the output token if `gss_accept_sec_context` errors.